### PR TITLE
Fix issues that caused the linter to break

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
     },
     "lint-staged": {
         "*.{js,vue}": "eslint --fix"
-    }
+    },
+    "eslint.workingDirectories": [
+        { "mode": "auto" }
+    ]
 }


### PR DESCRIPTION
The lint was showing this error and did not lint a thing. The fix referenced here finally did the trick:
https://github.com/microsoft/vscode-eslint/issues/696#issuecomment-566949199

<img width="472" alt="Schermafbeelding 2020-11-13 om 08 28 14" src="https://user-images.githubusercontent.com/498985/99042489-1782da00-258d-11eb-854d-0ee5f3957a33.png">