### PR TITLE
fix main entry module path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "src/index.js"
     ],
     "description": "funda's vue.js components library",
-    "main": "index.js",
+    "main": "src/index.js",
     "repository": "github:funda-frontend/ui",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Fixing the main entry module path on module we can now import components like
```js 
import { UiInput } from '@funda/ui'
```
instead of

```js 
import { UiInput } from '@funda/ui/src/index.js'
```
