### PR TITLE
Fix code examples and duplicate story title warnings

### DIFF
--- a/src/stories/ui-badge.stories.js
+++ b/src/stories/ui-badge.stories.js
@@ -5,9 +5,12 @@ export default {
     component: UiBadge,
 };
 
-const Template = () => ({
+const Template = args => ({
     components: { UiBadge },
-    template: '<ui-badge>Badge</ui-badge>',
+    template: `
+        <ui-badge>
+            Badge
+        </ui-badge>`,
 });
 
 export const Badge = Template.bind({});

--- a/src/stories/ui-button-group.stories.js
+++ b/src/stories/ui-button-group.stories.js
@@ -2,16 +2,17 @@ import UiButton from '@/components/ui-button.vue';
 import UiButtonGroup from '@/components/ui-button-group.vue';
 
 export default {
-    title: 'Forms/Button',
+    title: 'Forms/Button/Button group',
     component: UiButtonGroup,
 };
 
-const Template = () => ({
+const Template = args => ({
     components: {
         UiButtonGroup,
         UiButton,
     },
-    template: `<ui-button-group>
+    template: `
+        <ui-button-group>
             <ui-button tone="secondary">Left</ui-button>
             <ui-button tone="secondary">Middle</ui-button>
             <ui-button tone="secondary">Right</ui-button>

--- a/src/stories/ui-card.stories.js
+++ b/src/stories/ui-card.stories.js
@@ -9,7 +9,7 @@ export default {
     argTypes: {},
 };
 
-const Template = () => ({
+const Template = args => ({
     components: { UiCard },
     template: ` <ui-card>
                     Card content
@@ -17,7 +17,7 @@ const Template = () => ({
 });
 export const Card = Template.bind({});
 
-const TemplateInside = () => ({
+const TemplateInside = args => ({
     components: { UiCard, UiNotification },
     template: ` <ui-card>
                     <template v-slot:title>
@@ -28,7 +28,7 @@ const TemplateInside = () => ({
 });
 export const CardTitleInside = TemplateInside.bind({});
 
-const TemplateSubtitleOutside = () => ({
+const TemplateSubtitleOutside = args => ({
     components: { UiCard, UiCardTitle },
     template: ` <div class="bg-light-2 p-4">
                     <ui-card-title>
@@ -46,7 +46,7 @@ const TemplateSubtitleOutside = () => ({
 });
 export const CardTitleSubtitleOutside = TemplateSubtitleOutside.bind({});
 
-const TemplateOutside = () => ({
+const TemplateOutside = args => ({
     components: { UiCard, UiCardTitle },
     template: ` <div class="bg-light-2 p-4">
                     <ui-card-title>
@@ -61,7 +61,7 @@ const TemplateOutside = () => ({
 });
 export const CardTitleOutside = TemplateOutside.bind({});
 
-const TemplateNotification = () => ({
+const TemplateNotification = args => ({
     components: { UiCard, UiNotification },
     template: ` <ui-card>
                     <template v-slot:notifications>
@@ -76,7 +76,7 @@ const TemplateNotification = () => ({
 });
 export const CardWithNotification = TemplateNotification.bind({});
 
-const TemplateTitleNotification = () => ({
+const TemplateTitleNotification = args => ({
     components: { UiCard, UiNotification },
     template: ` <ui-card>
                     <template v-slot:title>
@@ -94,7 +94,7 @@ const TemplateTitleNotification = () => ({
 });
 export const CardTitleNotification = TemplateTitleNotification.bind({});
 
-const TemplateImage = () => ({
+const TemplateImage = args => ({
     components: { UiCardImage },
     template: ` <ui-card-image src="https://placekitten.com/200/300" alt="A kitty cat">
                     Card content

--- a/src/stories/ui-checkbox-group.stories.js
+++ b/src/stories/ui-checkbox-group.stories.js
@@ -1,7 +1,7 @@
 import UiCheckboxGroup from '@/components/ui-checkbox-group.vue';
 
 export default {
-    title: 'Forms/Checkbox',
+    title: 'Forms/Checkbox/Checkbox group',
     component: UiCheckboxGroup,
     argTypes: {
         disabled: {

--- a/src/stories/ui-form-group.stories.js
+++ b/src/stories/ui-form-group.stories.js
@@ -10,7 +10,7 @@ export default {
     component: UiFormGroup,
 };
 
-const Template = () => ({
+const Template = args => ({
     components: { UiFormGroup, UiLabel, UiInput, UiSelect, UiTextarea },
     template: ` <div>
                     <ui-form-group>
@@ -29,7 +29,7 @@ const Template = () => ({
 });
 export const FormGroup = Template.bind({});
 
-const TemplateInvalid = () => ({
+const TemplateInvalid = args => ({
     components: {
         UiFormGroup,
         UiLabel,

--- a/src/stories/ui-label.stories.js
+++ b/src/stories/ui-label.stories.js
@@ -5,9 +5,12 @@ export default {
     component: UiLabel,
 };
 
-const Template = () => ({
+const Template = args => ({
     components: { UiLabel },
-    template: '<ui-label>Label</ui-label>',
+    template: `
+        <ui-label>
+            Label
+        </ui-label>`,
 });
 
 export const Label = Template.bind({});

--- a/src/stories/ui-radio-group.stories.js
+++ b/src/stories/ui-radio-group.stories.js
@@ -1,7 +1,7 @@
 import UiRadioGroup from '@/components/ui-radio-group.vue';
 
 export default {
-    title: 'Forms/Radio',
+    title: 'Forms/Radio/Radio group',
     component: UiRadioGroup,
     argTypes: {
         disabled: {


### PR DESCRIPTION
We need to pass `args` in order for the code examples to render correctly. See results in the before and after screenshot down below. Also this change includes the unique naming of stories, which was throwing some warnings.

<img width="1042" alt="Schermafbeelding 2021-02-19 om 13 55 43" src="https://user-images.githubusercontent.com/498985/108508869-c33e7300-72bc-11eb-8f7b-fd62b4ebd75c.png">
<img width="1046" alt="Schermafbeelding 2021-02-19 om 13 55 57" src="https://user-images.githubusercontent.com/498985/108508873-c5083680-72bc-11eb-90bb-26ff1e56e864.png">
