### PR TITLE
fix(ui-card-image): add missing slot

### DIFF
--- a/src/components/ui-card-image.vue
+++ b/src/components/ui-card-image.vue
@@ -9,7 +9,7 @@
                 />
             </div>
         </template>
-        Card content
+        <slot />
     </ui-card>
 </template>
 


### PR DESCRIPTION
So I forgot to add the actual slot so the component can actually receive content. This PR fixes that.