### PR TITLE
fix(ui-tab): align ui-tab hover state with Design System

### DIFF
--- a/src/components/ui-tab.vue
+++ b/src/components/ui-tab.vue
@@ -1,11 +1,11 @@
 <template>
     <button
         role="tab"
-        class="float-left cursor-pointer outline-none focus:outline-none leading-7 border-b-2 py-2 px-6 hover:text-blue-2 hover:border-blue-2 hover:bg-blue-5"
+        class="float-left cursor-pointer outline-none focus:outline-none leading-7 border-b-2 py-2 px-6 hover:bg-blue-5"
         :aria-selected="selected"
         :class="{
             'text-blue-2 border-blue-2 bg-blue-5': selected,
-            'text-light-1 border-light-1 bg-white': !selected,
+            'text-dark-2 border-light-1 bg-white': !selected,
         }"
         v-bind="$attrs"
         v-on="$listeners"


### PR DESCRIPTION
This PR aims to match the tab component with the Design System in Abstract. Improved:

- The color of the not active tabs is now darker, to improve readability
- The hover and selected state now differ slightly, to always indicate what tab is selected