### PR TITLE
feat(modal): avoid rendering of h2 element when no title is given

### DIFF
--- a/src/components/ui-modal.vue
+++ b/src/components/ui-modal.vue
@@ -19,7 +19,7 @@
                 data-test-modal
             >
                 <header class="flex mb-5 mx-12 mt-10">
-                    <h2 class="m-0 font-semibold text-2xl">
+                    <h2 v-if="$slots.header" class="m-0 font-semibold text-2xl">
                         <slot name="header"></slot>
                     </h2>
                     <button


### PR DESCRIPTION
When using this Modal and you want to not give it a title in the header it would still render the h2. Using this v-if it will only render the h2 when used.