### PR TITLE
feat(icon): make it possible to overwrite the size of the icon

### DIFF
--- a/src/components/ui-icon.vue
+++ b/src/components/ui-icon.vue
@@ -1,6 +1,6 @@
 <template>
-    <!-- eslint-disable-next-line vue/no-v-html -->
-    <div class="fill-current h-6 w-6 align-middle" v-html="thisIcon"></div>
+    <!-- eslint-disable vue/no-v-html -->
+    <div :class="['fill-current, align-middle', size]" v-html="thisIcon"></div>
 </template>
 
 <script>
@@ -11,6 +11,10 @@ export default {
         icon: {
             type: String,
             required: true,
+        },
+        size: {
+            type: String,
+            default: 'h-6 w-6',
         },
     },
     computed: {

--- a/src/components/ui-icon.vue
+++ b/src/components/ui-icon.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- eslint-disable vue/no-v-html -->
-    <div :class="['fill-current, align-middle', size]" v-html="thisIcon"></div>
+    <div :class="['fill-current align-middle', size]" v-html="thisIcon"></div>
 </template>
 
 <script>

--- a/src/stories/ui-icon.stories.js
+++ b/src/stories/ui-icon.stories.js
@@ -192,13 +192,20 @@ export default {
                 options: iconsList,
             },
         },
+        size: {
+            defaultValue: 'h-6 w-6',
+            description: 'Change the size of the icon using tailwind classes',
+            control: {
+                type: 'text',
+            },
+        },
     },
 };
 
 const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { UiIcon },
-    template: '<ui-icon :icon="icon"></ui-icon>',
+    template: '<ui-icon :icon="icon" :size="size"></ui-icon>',
 });
 
 export const Icon = Template.bind({});


### PR DESCRIPTION
You are able to change the classes by setting it on the component. However, the classes in tailwind have a certain priority, so instead of adding the class while the other co-exists, we replace the class. That way h-6 can never overwrite h-4.

If we don't do this I would need to use an inline/scoped style to overwrite the size.