### PR TITLE
style(tooltip): remove focus outline

### DIFF
--- a/src/components/ui-tooltip.vue
+++ b/src/components/ui-tooltip.vue
@@ -13,7 +13,7 @@
                 <slot name="content" />
             </div>
 
-            <button slot="reference">
+            <button slot="reference" class="focus:outline-none">
                 <slot name="reference" />
             </button>
         </popper>


### PR DESCRIPTION
Black border outline around button is displayed when focused.