### PR TITLE
feat(tooltip): make popper options versatile

### DIFF
--- a/src/components/ui-tooltip.vue
+++ b/src/components/ui-tooltip.vue
@@ -1,10 +1,6 @@
 <template>
     <div>
-        <popper
-            :key="popperKey"
-            :trigger="trigger"
-            :options="{ placement: side }"
-        >
+        <popper :trigger="trigger" :options="options">
             <div
                 role="tooltip"
                 :class="backgroundClass"
@@ -42,17 +38,12 @@ export default {
                     value
                 ),
         },
-        side: {
-            type: String,
-            default: 'bottom',
-            validator: (value) =>
-                ['top', 'right', 'bottom', 'left'].includes(value),
+        options: {
+            type: Object,
+            default: () => {},
         },
     },
     computed: {
-        popperKey() {
-            return `${this.side}-${this.trigger}`;
-        },
         backgroundClass() {
             const specificClasses = {
                 white: 'bg-white',

--- a/src/stories/ui-tooltip.stories.js
+++ b/src/stories/ui-tooltip.stories.js
@@ -16,10 +16,9 @@ export default {
                 options: ['hover', 'clickToOpen', 'clickToToggle', 'focus'],
             },
         },
-        side: {
+        options: {
             control: {
-                type: 'select',
-                options: ['top', 'right', 'bottom', 'left'],
+                type: 'object',
             },
         },
     },
@@ -28,7 +27,7 @@ export default {
 const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { UiTooltip },
-    template: `<ui-tooltip :trigger="trigger" :side="side" :background="background">
+    template: `<ui-tooltip :trigger="trigger" :options="options" :background="background">
                     <template v-slot:content>
                         Lorem ipsum dolor sit amet, consectetur adipiscing.
                     </template>
@@ -41,8 +40,15 @@ const Template = (args, { argTypes }) => ({
 export const Tooltip = Template.bind({});
 Tooltip.args = {
     background: 'light',
-    trigger: 'hover',
-    side: 'bottom',
+    trigger: 'click',
+    options: {
+        placement: 'top',
+        modifiers: {
+            offset: {
+                offset: '1000px,0',
+            },
+        },
+    },
 };
 Tooltip.decorators = [
     () => ({

--- a/src/stories/ui-tooltip.stories.js
+++ b/src/stories/ui-tooltip.stories.js
@@ -42,7 +42,8 @@ Tooltip.args = {
     background: 'light',
     trigger: 'click',
     options: {
-        placement: 'top',
+        // https://github.com/RobinCK/vue-popper#props
+        placement: 'bottom',
         modifiers: {
             offset: {
                 offset: '1000px,0',


### PR DESCRIPTION
Make the tooltip (popper) options versatile instead of offering strict placement support.

Also deleted the key because I don't think it offers any value.