### PR TITLE
Add optional horizontal alignement for radio's

### DIFF
--- a/src/__tests__/ui-radio-group.test.js
+++ b/src/__tests__/ui-radio-group.test.js
@@ -1,0 +1,14 @@
+import { shallowMount } from '@vue/test-utils';
+import UiRadioGroup from '@/components/ui-radio-group.vue';
+
+describe('UiRadioGroup', () => {
+    let wrapper;
+    beforeEach(() => {
+        wrapper = shallowMount(UiRadioGroup);
+    });
+
+    it('Should set flex class when alignHorizontal is true', () => {
+        wrapper.setProps({ alignHorizontal: true });
+        expect(wrapper.find('div.flex').exists());
+    });
+});

--- a/src/__tests__/ui-radio.test.js
+++ b/src/__tests__/ui-radio.test.js
@@ -1,0 +1,14 @@
+import { shallowMount } from '@vue/test-utils';
+import UiRadio from '@/components/ui-radio.vue';
+
+describe('UiRadio', () => {
+    let wrapper;
+    beforeEach(() => {
+        wrapper = shallowMount(UiRadio);
+    });
+
+    it('Should set flex class when alignHorizontal is true', () => {
+        wrapper.setProps({ alignHorizontal: true });
+        expect(wrapper.find('div.flex-1').exists());
+    });
+});

--- a/src/components/ui-radio-group.vue
+++ b/src/components/ui-radio-group.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div :class="{ 'md:flex': alignHorizontal }">
         <ui-radio
             v-for="item in items"
             :id="`${id}_${item.value}`"
@@ -8,6 +8,7 @@
             :name="name"
             :checked="item.value === selected"
             :disabled="disabled"
+            :align-horizontal="alignHorizontal"
             @change="$emit('change', $event)"
         >
             {{ item.label }}
@@ -39,6 +40,10 @@ export default {
             default: '',
         },
         disabled: {
+            type: Boolean,
+            default: false,
+        },
+        alignHorizontal: {
             type: Boolean,
             default: false,
         },

--- a/src/components/ui-radio.vue
+++ b/src/components/ui-radio.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div :class="{ 'md:flex-1': alignHorizontal }">
         <div class="py-2">
             <input
                 :id="id"
@@ -37,6 +37,10 @@ export default {
         name: {
             type: String,
             default: 'funda_radio_input',
+        },
+        alignHorizontal: {
+            type: Boolean,
+            default: false,
         },
     },
 };

--- a/src/stories/ui-radio-group.stories.js
+++ b/src/stories/ui-radio-group.stories.js
@@ -9,6 +9,11 @@ export default {
                 options: [true, false],
             },
         },
+        alignHorizontal: {
+            control: {
+                options: [true, false],
+            },
+        },
     },
 };
 
@@ -16,7 +21,7 @@ const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { UiRadioGroup },
     template:
-        '<ui-radio-group :selected="selected" :items="items" :disabled="disabled" id="radio-group-id" @change="onChange" />',
+        '<ui-radio-group :selected="selected" :items="items" :disabled="disabled" id="radio-group-id" :align-horizontal="alignHorizontal" @change="onChange" />',
 });
 
 export const RadioGroup = Template.bind({});
@@ -45,5 +50,6 @@ RadioGroup.args = {
     ],
     selected: 'item2',
     disabled: false,
+    alignHorizontal: false,
     onChange() {},
 };


### PR DESCRIPTION
This allows the lay-out to have radio's horizontally side-by-side, instead of only being able to stack them vertically. Nothing changes for current implementations. On small screens the radios will always stack, regardless of the settings. 