### PR TITLE
feat(ui-radio): add prop to center radio button vertically

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,22 @@ export default {
 
 https://funda-frontend.github.io/ui/latest/
 
+# Contributing
 
 ## How to push your changes
 
 This repo uses [commitlint](https://github.com/conventional-changelog/commitlint), which means that it follows specific commit message rules.
-If the messages are not on the expected format it wont be possible to commit/push your changes.
+If the messages are not in the expected format, it won't be possible to commit/push your changes.
 
-Example of commit message: 
+Examples of commit messages:
 
-    'feat(branch_name): commit message' or 'fix(branch_name): commit message'
+* `feat(branch_name): commit message`
+* `fix(branch_name): commit message`
 
 PS: It is recommended to use the terminal for commit, if you use any GUI it might be necessary to update you local variable PATH on your GUI.
-Reference: [Husky issues](https://typicode.github.io/husky/#/?id=command-not-found) 
+Reference: [Husky issues](https://typicode.github.io/husky/#/?id=command-not-found)
+
+## Releasing a new version
+
+This project has GitHub integrations that will automatically increment the package version and generate a changelog entry based on the new commits.
+Simply following the commitlint standard and merging your changes into master will release the project.

--- a/src/components/ui-radio.vue
+++ b/src/components/ui-radio.vue
@@ -11,6 +11,7 @@
             />
             <ui-label
                 class="cursor-pointer flex py-1 hover:text-blue-1"
+                :class="{ 'items-center': centerRadioVertically }"
                 :for="id"
             >
                 <div
@@ -39,6 +40,10 @@ export default {
             default: 'funda_radio_input',
         },
         alignHorizontal: {
+            type: Boolean,
+            default: false,
+        },
+        centerRadioVertically: {
             type: Boolean,
             default: false,
         },

--- a/src/stories/ui-radio.stories.js
+++ b/src/stories/ui-radio.stories.js
@@ -29,7 +29,13 @@ const TemplateSlotLabel = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { UiRadio },
     template: `
-        <ui-radio change="onChange" :disabled="disabled" id="input-slot-extras-id" :checked="true">
+        <ui-radio
+            :centerRadioVertically="centerRadioVertically"
+            :checked="true"
+            :disabled="disabled"
+            change="onChange"
+            id="input-slot-extras-id"
+        >
             <div>
                 <h3 class="font-bold">Radio Title</h3>
                 <div class="text-dark-2">Description</div>
@@ -40,5 +46,6 @@ const TemplateSlotLabel = (args, { argTypes }) => ({
 export const InputSlotLabel = TemplateSlotLabel.bind({});
 InputSlotLabel.args = {
     disabled: false,
+    centerRadioVertically: false,
     onChange() {},
 };


### PR DESCRIPTION
This would allow for the [UICenteredRadio] component in alf to be removed and replaced with the ui-radio component with this new prop enabled.

Please suggest any improvements to naming the `centerRadioVertically` prop and any improvements to procedure regarding this pull request.