### PR TITLE
feat(card-image): add the option for a small image

### DIFF
--- a/src/components/ui-card-image.vue
+++ b/src/components/ui-card-image.vue
@@ -1,13 +1,22 @@
 <template>
     <ui-card :variant="variant">
         <template #image>
-            <div class="overflow-hidden relative h-0 pt-40 md:rounded-t-sm">
+            <div
+                v-if="size === 'big'"
+                class="overflow-hidden relative h-0 pt-40 md:rounded-t-sm"
+            >
                 <img
                     class="absolute block w-full h-full top-0 left-0 object-cover"
                     v-bind="$attrs"
                     loading="lazy"
                 />
             </div>
+            <img
+                v-else
+                class="block px-0 md:px-4 pt-0 md:pt-4 w-full md:w-auto rounded-t-sm md:rounded-none"
+                v-bind="$attrs"
+                loading="lazy"
+            />
         </template>
         <slot />
     </ui-card>
@@ -25,6 +34,10 @@ export default {
         variant: {
             type: String,
             default: 'default',
+        },
+        size: {
+            type: String,
+            default: 'big',
         },
     },
 };

--- a/src/components/ui-card-image.vue
+++ b/src/components/ui-card-image.vue
@@ -1,8 +1,14 @@
 <template>
     <ui-card :variant="variant">
         <template #image>
+            <img
+                v-if="smallImage"
+                class="block px-0 md:px-4 pt-0 md:pt-4 w-full md:w-auto rounded-t-sm md:rounded-none"
+                v-bind="$attrs"
+                loading="lazy"
+            />
             <div
-                v-if="size === 'big'"
+                v-else
                 class="overflow-hidden relative h-0 pt-40 md:rounded-t-sm"
             >
                 <img
@@ -11,12 +17,6 @@
                     loading="lazy"
                 />
             </div>
-            <img
-                v-else
-                class="block px-0 md:px-4 pt-0 md:pt-4 w-full md:w-auto rounded-t-sm md:rounded-none"
-                v-bind="$attrs"
-                loading="lazy"
-            />
         </template>
         <slot />
     </ui-card>
@@ -35,9 +35,9 @@ export default {
             type: String,
             default: 'default',
         },
-        size: {
-            type: String,
-            default: 'big',
+        smallImage: {
+            type: Boolean,
+            default: false,
         },
     },
 };

--- a/src/stories/ui-card.stories.js
+++ b/src/stories/ui-card.stories.js
@@ -110,17 +110,15 @@ export const CardTitleNotification = TemplateTitleNotification.bind({});
 const TemplateImage = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { UiCardImage },
-    template: ` <ui-card-image :variant="variant" src="https://placekitten.com/200/300" alt="A kitty cat">
+    template: ` <ui-card-image v-bind="$props">
                     Card content
                 </ui-card-image>`,
 });
-export const CardImage = TemplateImage.bind({});
 
-const TemplateImageSmall = (args, { argTypes }) => ({
-    props: Object.keys(argTypes),
-    components: { UiCardImage },
-    template: ` <ui-card-image :variant="variant" small-image src="https://placekitten.com/300/200" alt="A kitty cat">
-                    Card content
-                </ui-card-image>`,
-});
-export const CardImageSmall = TemplateImageSmall.bind({});
+export const CardImage = TemplateImage.bind({});
+CardImage.args = {
+    variant: 'default',
+    smallImage: false,
+    src: 'https://placekitten.com/300/200',
+    alt: 'A kitty cat',
+};

--- a/src/stories/ui-card.stories.js
+++ b/src/stories/ui-card.stories.js
@@ -119,7 +119,7 @@ export const CardImage = TemplateImage.bind({});
 const TemplateImageSmall = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { UiCardImage },
-    template: ` <ui-card-image :variant="variant" size="small" src="https://placekitten.com/300/200" alt="A kitty cat">
+    template: ` <ui-card-image :variant="variant" small-image src="https://placekitten.com/300/200" alt="A kitty cat">
                     Card content
                 </ui-card-image>`,
 });

--- a/src/stories/ui-card.stories.js
+++ b/src/stories/ui-card.stories.js
@@ -115,3 +115,12 @@ const TemplateImage = (args, { argTypes }) => ({
                 </ui-card-image>`,
 });
 export const CardImage = TemplateImage.bind({});
+
+const TemplateImageSmall = (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { UiCardImage },
+    template: ` <ui-card-image :variant="variant" size="small" src="https://placekitten.com/300/200" alt="A kitty cat">
+                    Card content
+                </ui-card-image>`,
+});
+export const CardImageSmall = TemplateImageSmall.bind({});


### PR DESCRIPTION
Next to the full width images we're already supporting with the image card component, we're seeing another pattern in the UI where we have a smaller image in the top of the card. On small screens this should cover the entire width of the screen and on desktop it should behave like a normal 'small' image in the content.

To support this I've extended the card image component. By default it will always show the image that was passed full width like we already did. If the option (prop) `size` is set, it will show the smaller variant.